### PR TITLE
gen_dat のパス設定にデフォルト値を追加

### DIFF
--- a/files/Segment/workspace/util/gen_dat/src/gen_dat.cpp
+++ b/files/Segment/workspace/util/gen_dat/src/gen_dat.cpp
@@ -20,7 +20,7 @@ vector<string> get_file_path(string input_dir) {
     glob_t globbuf;
     vector<string> files;
     auto glob_files = [&](const string& suffix) {
-        glob((input_dir + "*." + suffix).c_str(), 0, NULL, &globbuf);
+        glob((input_dir + "/*." + suffix).c_str(), 0, NULL, &globbuf);
         for (size_t i = 0; i < globbuf.gl_pathc; i++) {
             files.push_back(globbuf.gl_pathv[i]);
         }
@@ -95,11 +95,13 @@ void process(const string& img_path,
 int main(int argc, char *argv[]) {
     try {
         const bool flip = (1 < argc && string(argv[1]) == "flip") ? true : false;
-        const auto img_path  = getenv("SIGNATE_TRAIN_IMG_DIR");
-        const auto anno_path = getenv("SIGNATE_TRAIN_ANNO_DIR");
-        if (img_path == nullptr || anno_path == nullptr) {
-            throw std::logic_error("[FATAL ERROR] Please set environment value: SIGNATE_TRAIN_IMG_DIR and SIGNATE_TRAIN_ANNO_DIR");
-        }
+        const auto img_env_path  = getenv("SIGNATE_TRAIN_IMG_DIR");
+        const auto anno_env_path = getenv("SIGNATE_TRAIN_ANNO_DIR");
+        const auto img_path  = (img_env_path != nullptr) ? img_env_path : "/workspace/Vitis-AI-Tutorials/files/Segment/workspace/data/signate/seg_train_images";
+        const auto anno_path = (anno_env_path != nullptr) ? anno_env_path : "/workspace/Vitis-AI-Tutorials/files/Segment/workspace/data/signate/seg_train_annotations";
+
+        std::cout << "the path of image data:      " << img_path << std::endl;
+        std::cout << "the path of annotation data: " << anno_path << std::endl;
 
         vector<string> img_files = get_file_path(img_path);
         vector<string> anno_files = get_file_path(anno_path);


### PR DESCRIPTION
環境変数でデータのパスを指定するようにしようと思ったが、 `.prototxt` とかあるしやっぱりつらい。  
ということで、

```
/workspace/Vitis-AI-Tutorials/files/Segment/workspace/data/
|-- bdd100k
|   `-- seg
|       |-- color_labels                 <- 配置
|       |-- images                       <- 配置
|       |-- labels                       <- 配置
|       |-- glob_files.py
|       `-- train_files.txt
|-- cityscapes
|   `-- img_seg.txt
`-- signate
    |-- filelist.txt
    |-- gen_filelist.py
    |-- seg_test_images                  <- 配置 (今まではここではなかった)
    |-- seg_train_annotations            <- 配置
    |-- seg_train_images                 <- 配置
    `-- viz_seg_train.py
```

のようにデータを配置する前提で進めたい。 `gen_dat` に関しては引き続き環境変数でパスを指定できるようになっているが、環境変数を指定しない場合は上記のディレクトリ構造となっていることを前提として動作する。